### PR TITLE
Fix single letter shortcuts

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=retroTerm
-version=0.1.0
+version=0.1.1
 author=Nick Reynolds,nick+retroTerm@arcanium.london
 maintainer=Nick Reynolds,nick+retroTerm@arcanium.london
 sentence=A library for creating user interfaces on an ANSI/VTxxx terminal with a microcontroller

--- a/src/retroTerm.cpp
+++ b/src/retroTerm.cpp
@@ -815,13 +815,20 @@ uint16_t ICACHE_FLASH_ATTR retroTerm::_shortcutLength(const uint8_t widgetIndex)
 uint16_t retroTerm::_shortcutLength(const uint8_t widgetIndex)
 #endif
 {
-	#if defined(__AVR__)
-	return(strlen_P((const char *) pgm_read_word (&keyLabels[_widgets[widgetIndex].shortcut])));
-	#elif defined(ESP8266) || defined(ESP32)
-	return(strlen_P(keyLabels[_widgets[widgetIndex].shortcut]));
-	#else
-	return(strlen(keyLabels[_widgets[widgetIndex].shortcut]));
-	#endif
+	if(_widgets[widgetIndex].shortcut > 31)	//It's a single character
+	{
+		return(1);
+	}
+	else
+	{
+		#if defined(__AVR__)
+		return(strlen_P((const char *) pgm_read_word (&keyLabels[_widgets[widgetIndex].shortcut])));
+		#elif defined(ESP8266) || defined(ESP32)
+		return(strlen_P(keyLabels[_widgets[widgetIndex].shortcut]));
+		#else
+		return(strlen(keyLabels[_widgets[widgetIndex].shortcut]));
+		#endif
+	}
 }
 
 #if defined(ESP8266) || defined(ESP32)
@@ -977,13 +984,20 @@ void retroTerm::_printKeyboardShortcut(const uint8_t widgetIndex)
 {
 	attributes(_widgets[widgetIndex].attributes);	//Set the right attributes
 	_terminalStream->print(F("["));
-	#if defined(__AVR__)
-	_printProgStr((const char *) pgm_read_word (&keyLabels[_widgets[widgetIndex].shortcut]));
-	#elif defined(ESP8266) || defined(ESP32)
-	_terminalStream->print(keyLabels[_widgets[widgetIndex].shortcut]);
-	#else
-	_terminalStream->print(keyLabels[_widgets[widgetIndex].shortcut]);
-	#endif
+	if(_widgets[widgetIndex].shortcut > 31)
+	{
+		_terminalStream->print(char(_widgets[widgetIndex].shortcut));
+	}
+	else
+	{
+		#if defined(__AVR__)
+		_printProgStr((const char *) pgm_read_word (&keyLabels[_widgets[widgetIndex].shortcut]));
+		#elif defined(ESP8266) || defined(ESP32)
+		_terminalStream->print(keyLabels[_widgets[widgetIndex].shortcut]);
+		#else
+		_terminalStream->print(keyLabels[_widgets[widgetIndex].shortcut]);
+		#endif
+	}
 	_terminalStream->print(F("]"));
 }
 

--- a/src/retroTerm.cpp
+++ b/src/retroTerm.cpp
@@ -93,7 +93,7 @@ void retroTerm::_processInput()
 				_mouseStatus = _mouseStatus & 0xEF;	//Gobble the mouse event
 				inputEventCaught = true;			//Stop looking for more events
 			}
-			if(_widgets[widgetId].shortcut != noKeyPressed && _widgets[widgetId].shortcut == _lastKeypress)	//Search for used keyboard shortcuts, which appear as 'clicks' of an object for simplicity. This gobbles up the keypress so the application doesn't see it
+			if(_widgets[widgetId].shortcut != noKeyPressed && _shortcutMatches(widgetId))	//Search for used keyboard shortcuts, which appear as 'clicks' of an object for simplicity. This gobbles up the keypress so the application doesn't see it
 			{
 				_clickWidget(widgetId);				//Do per-widget-type click handling, only if clickable
 				_lastKeypress = noKeyPressed;		//Gobble the keypress and stop looking for more shortcuts
@@ -287,6 +287,26 @@ void retroTerm::_processInput()
 				_lastKeypress = noKeyPressed;								//Gobble up the keypress as line editing is occuring
 			}
 		}
+	}
+}
+
+#if defined(ESP8266) || defined(ESP32)
+bool ICACHE_FLASH_ATTR retroTerm::_shortcutMatches(const uint8_t widgetId)
+#else
+bool retroTerm::_shortcutMatches(const uint8_t widgetId)
+#endif
+{
+	if(_widgets[widgetId].shortcut == _lastKeypress)
+	{
+		return(true);
+	}
+	else if(_widgets[widgetId].shortcut > 31 && _lastKeypress > 31 && toupper(_widgets[widgetId].shortcut) == toupper(_lastKeypress))
+	{
+		return(true);
+	}
+	else
+	{
+		return(false);
 	}
 }
 

--- a/src/retroTerm.h
+++ b/src/retroTerm.h
@@ -939,6 +939,7 @@ class retroTerm
 
 		void _displayKeyboardShortcut(uint8_t);			//Show keyboard shortcut on a widget, doing all the lifting of centering etc.
 		void _printKeyboardShortcut(uint8_t);			//Does the actual print. Uses appropriate method if shortcut is in a PROGMEM
+		bool _shortcutMatches(uint8_t);					//Does case insensitive matching of keyboard shortcuts
 
 		void _displayLabel(uint8_t widgetId);			//Show the label on a widget (will include shortcut if inline)
 		void _printLabel(uint8_t);						//Does the actual print. Uses appropriate method if label is in a PROGMEM


### PR DESCRIPTION
Use of the library showed single letter widget shortcut keys would cause a crash due to attempts to access flash memory outside of array bounds. 

Single letter widget shortcut keys are now also case insensitive, ie. 'Y' and 'y' display as set, but the keypress is case-insensitive. Which seems a more intuitive way to handle this.